### PR TITLE
chore: clean up change logic of first condition for mars type data calls

### DIFF
--- a/src/app/actions/favoriteRover.ts
+++ b/src/app/actions/favoriteRover.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { FavoriteMarsPhoto, MarsPhoto } from "@/types/MarsRover/marsRover";
+import { MarsPhoto } from "@/types/MarsRover/marsRover";
 import { User } from "@/types/Users/users";
 import { PrismaClient } from "@prisma/client";
 import { revalidatePath } from "next/cache";
@@ -13,7 +13,7 @@ export async function markImageAsFavorite(
 ) {
   try {
     const user = await prisma.user.findUnique({
-      where: { email: userData.email },
+      where: { email: userData.email }
     });
 
     if (!user) {
@@ -21,27 +21,27 @@ export async function markImageAsFavorite(
     }
 
     let existingMarsData = await prisma.marsRoverData.findFirst({
-      where: { jsonData: { equals: marsPhoto } },
+      where: { jsonData: { equals: marsPhoto } }
     });
 
     if (!existingMarsData) {
       existingMarsData = await prisma.marsRoverData.create({
         data: {
-          jsonData: marsPhoto,
-        },
+          jsonData: marsPhoto
+        }
       });
     }
 
     let existingFavorite = await prisma.favoriteMarsRoverData.findFirst({
-      where: { userId: user.id, marsRoverDataId: existingMarsData.id },
+      where: { userId: user.id, marsRoverDataId: existingMarsData.id }
     });
 
     if (!existingFavorite) {
       existingFavorite = await prisma.favoriteMarsRoverData.create({
         data: {
           user: { connect: { id: user.id } },
-          marsRoverData: { connect: { id: existingMarsData.id } },
-        },
+          marsRoverData: { connect: { id: existingMarsData.id } }
+        }
       });
     }
 
@@ -62,7 +62,7 @@ export async function unMarkImageAsFavorite(userData: User, marsPhoto: any) {
   let id;
   try {
     const user = await prisma.user.findUnique({
-      where: { email: userData.email },
+      where: { email: userData.email }
     });
 
     if (!user) {
@@ -71,12 +71,12 @@ export async function unMarkImageAsFavorite(userData: User, marsPhoto: any) {
 
     if (marsPhoto.marsRoverDataId) {
       existingMarsData = await prisma.marsRoverData.findFirst({
-        where: { jsonData: { equals: marsPhoto.marsRoverDataID } },
+        where: { id: marsPhoto.marsRoverDataID }
       });
       id = marsPhoto.marsRoverDataId;
     } else {
       existingMarsData = await prisma.marsRoverData.findFirst({
-        where: { jsonData: { equals: marsPhoto } },
+        where: { jsonData: { equals: marsPhoto } }
       });
       id = existingMarsData?.id;
     }
@@ -89,8 +89,8 @@ export async function unMarkImageAsFavorite(userData: User, marsPhoto: any) {
       await prisma.favoriteMarsRoverData.findFirst({
         where: {
           userId: user.id,
-          marsRoverDataId: id,
-        },
+          marsRoverDataId: id
+        }
       });
 
     if (!favoriteMarsPhotoToDelete) {
@@ -99,7 +99,7 @@ export async function unMarkImageAsFavorite(userData: User, marsPhoto: any) {
     }
 
     return prisma.favoriteMarsRoverData.delete({
-      where: { id: favoriteMarsPhotoToDelete.id },
+      where: { id: favoriteMarsPhotoToDelete.id }
     });
   } catch (error) {
     console.error("Error unmarking image as favorite:", error);
@@ -118,19 +118,19 @@ export async function getExistingMarsPhoto({ email }: User, data: any) {
 
     if (data.marsRoverDataId) {
       existingMarsRoverData = await prisma.marsRoverData.findFirst({
-        where: { jsonData: { equals: data.marsRoverDataID } },
+        where: { id: data.marsRoverDataID }
       });
       id = data.marsRoverDataId;
     } else {
       existingMarsRoverData = await prisma.marsRoverData.findFirst({
-        where: { jsonData: { equals: data } },
+        where: { jsonData: { equals: data } }
       });
 
       id = existingMarsRoverData?.id;
     }
 
     const user = await prisma.user.findUnique({
-      where: { email },
+      where: { email }
     });
 
     if (!user) {
@@ -141,7 +141,7 @@ export async function getExistingMarsPhoto({ email }: User, data: any) {
     }
 
     const existingFavorite = await prisma.favoriteMarsRoverData.findFirst({
-      where: { userId: user.id, marsRoverDataId: id as string },
+      where: { userId: user.id, marsRoverDataId: id as string }
     });
 
     return existingFavorite;
@@ -154,7 +154,7 @@ export async function getExistingMarsPhoto({ email }: User, data: any) {
 export async function getFavoriteMarsPhotos(userData: User) {
   try {
     const user = await prisma.user.findUnique({
-      where: { email: userData.email },
+      where: { email: userData.email }
     });
 
     if (!user) {
@@ -163,7 +163,7 @@ export async function getFavoriteMarsPhotos(userData: User) {
 
     const favoriteMarsPhotos = await prisma.favoriteMarsRoverData.findMany({
       where: { userId: user.id },
-      include: { marsRoverData: true },
+      include: { marsRoverData: true }
     });
 
     return favoriteMarsPhotos;

--- a/src/app/dashboard/favorites/apods/page.tsx
+++ b/src/app/dashboard/favorites/apods/page.tsx
@@ -9,20 +9,21 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Solar System | Favorite APODs",
-  description: "Your Favorite APODs.",
+  description: "Your Favorite APODs."
 };
 
 export default async function FavoriteApods() {
   const session = await getServerSession(options);
   if (!session) return null;
+
   const data = await getFavoriteApods(session.user as any);
   const totalApods = data.length;
-  let message;
-  if (totalApods === 1) {
-    message = "1 favorite Astronomy Picture of the Day";
-  } else {
-    message = `${totalApods} favorite Astronomy Pictures of the Day`;
-  }
+
+  const message =
+    totalApods === 1
+      ? "1 Favorite Astronomy Picture of the Day"
+      : `${totalApods} Favorite Astronomy Pictures of the Day`;
+
   return (
     <>
       <Navbar />

--- a/src/app/dashboard/favorites/marsPhotos/page.tsx
+++ b/src/app/dashboard/favorites/marsPhotos/page.tsx
@@ -10,7 +10,7 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Solar System | Mars Photos",
-  description: "Your Favorite Mars Photos.",
+  description: "Your Favorite Mars Photos."
 };
 
 export default async function FavoriteApods() {
@@ -19,13 +19,14 @@ export default async function FavoriteApods() {
 
   const data: any = await getFavoriteMarsPhotos(session.user as any);
   if (!data) return null;
+
   const totalPhotos = data.length;
-  let message;
-  if (totalPhotos === 1) {
-    message = "1 Favorite Photo of Mars";
-  } else {
-    message = `${totalPhotos} Favorite Photos of Mars`;
-  }
+
+  const message =
+    totalPhotos === 1
+      ? "1 Favorite Photo of Mars"
+      : `${totalPhotos} Favorite Photos of Mars`;
+
   return (
     <>
       <Navbar />

--- a/src/lib/users/users.ts
+++ b/src/lib/users/users.ts
@@ -16,20 +16,23 @@ async function getUsers() {
 
 async function getOrCreateUser(password: string, name: string, email: string) {
   try {
-    const hashedPassword = await bcrypt.hash(password, 10);
+    const hashedPassword = await bcrypt.hash(
+      password,
+      Number(process.env.SECRET_SALT_ROUNDS)
+    );
 
     const user = await prisma.user.upsert({
       where: {
-        userName: name,
+        userName: name
       },
       update: {
-        password: hashedPassword,
+        password: hashedPassword
       },
       create: {
         password: hashedPassword,
         userName: name,
-        email: email,
-      },
+        email: email
+      }
     });
 
     return user;
@@ -45,8 +48,8 @@ async function getUserByUsername(username: string) {
   try {
     const user = await prisma.user.findUnique({
       where: {
-        userName: username,
-      },
+        userName: username
+      }
     });
     return user;
   } catch (error) {


### PR DESCRIPTION
This is supposed to fix an issue that is caused when a user would quickly delete and try to re-favorite that same image before the page was re-validated. 