### PR TITLE
feat: add detail button for fav apods

### DIFF
--- a/src/app/dashboard/favorites/apods/page.tsx
+++ b/src/app/dashboard/favorites/apods/page.tsx
@@ -6,6 +6,7 @@ import Favorites from "@/components/Apods/Favorites";
 import Navbar from "@/components/NavBar/NavBar";
 
 import type { Metadata } from "next";
+import ApodDetails from "@/components/Details/Apods";
 
 export const metadata: Metadata = {
   title: "Solar System | Favorite APODs",
@@ -20,7 +21,7 @@ export default async function FavoriteApods() {
   const totalApods = data.length;
 
   const message =
-    totalApods === 1 ? "1 APOD Found" : `${totalApods} APODS Found`;
+    totalApods === 1 ? "1 APOD Found" : `${totalApods} APODs Found`;
 
   return (
     <>
@@ -59,15 +60,10 @@ export default async function FavoriteApods() {
                   />
                 )}
               </div>
-              <div className="flex justify-center mt-2">
+              <div className="flex justify-center mt-2 items-center space-x-10">
                 <Favorites data={apod} />
+                <ApodDetails apod={apod.apod} />
               </div>
-              <p className="m-2 text-center">{apod.apod.explanation}</p>
-              {apod.apod.copyRight && (
-                <p className="text-sm text-center">
-                  &copy; {apod.apod.copyRight}
-                </p>
-              )}
             </div>
           ))}
         </div>

--- a/src/components/Details/Apods.tsx
+++ b/src/components/Details/Apods.tsx
@@ -1,0 +1,47 @@
+"use client";
+import { useState } from "react";
+
+const ApodDetails = ({ apod }: any) => {
+  const [open, setOpen] = useState<boolean>(false);
+  const { copyRight, title, explanation } = apod;
+
+  const handleClick = () => {
+    setOpen(!open);
+  };
+
+  return (
+    <div>
+      <button
+        className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-1 px-1 rounded"
+        onClick={handleClick}
+      >
+        Details
+      </button>
+
+      {open && (
+        <div className="overflow-hidden">
+          <div
+            onClick={handleClick}
+            className="fixed top-0 left-0 w-full h-full flex items-center justify-center bg-gray-900 bg-opacity-50 z-50"
+          >
+            <div className="bg-white p-4 md:p-8 rounded-lg shadow-lg overflow-y-auto max-h-full">
+              <h1 className="text-xl md:text-3xl font-bold text-gray-800 mb-4">
+                {title}
+              </h1>
+              <p className="text-lg md:text-xl text-gray-600 mb-4">
+                {explanation}
+              </p>
+              {copyRight && (
+                <p className="text-lg md:text-xl text-gray-600">
+                  &copy; {copyRight}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ApodDetails;

--- a/src/types/Apods/apods.d.ts
+++ b/src/types/Apods/apods.d.ts
@@ -18,3 +18,16 @@ export type FavoriteApod = {
   apod: Apod;
   apodId: String;
 };
+
+export type Apods = [
+  apod: {
+    copyright: string;
+    date: string;
+    explanation: string;
+    hdurl: string;
+    media_type: string;
+    service_version: string;
+    title: string;
+    url: string;
+  }
+];


### PR DESCRIPTION
Previously favorite APODs would all render with their details making the page scroll for a very long time. This PR puts the details into a pop up. 