### PR TITLE
fix: apod date format

### DIFF
--- a/src/components/Apods/apodByDate.tsx
+++ b/src/components/Apods/apodByDate.tsx
@@ -10,7 +10,7 @@ import getApodByDate from "@/app/actions/apodData";
 import { Apod } from "@/types/Apods/apods";
 import Favorites from "./Favorites";
 
-const today = moment().format();
+const today = moment().format("YYYY-MM-DD");
 
 export default function ApodSelection() {
   const [startDate, setStartDate] = useState(today);


### PR DESCRIPTION
The date was not being formatted, so that is why it couldn't find the correct date on load.